### PR TITLE
ELECTRON-1009: adding per monitor DPI scaling support

### DIFF
--- a/ScreenSnippet.csproj
+++ b/ScreenSnippet.csproj
@@ -36,6 +36,9 @@
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -118,6 +121,7 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SnippingWindow.xaml.cs
+++ b/SnippingWindow.xaml.cs
@@ -76,8 +76,12 @@ namespace Paragon.Plugins.ScreenCapture
             rect.X = rect.Left - 80 + SystemInformation.VirtualScreen.Left;
 
             var screen = Screen.GetBounds(rect);
-            Top = top < screen.Top ? screen.Top : top;
-            Left = left < screen.Left ? screen.Left : left;
+            Matrix m = System.Windows.PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice;
+            double dx = m.M11;
+            double dy = m.M22;
+
+            Top = top < screen.Top ? (screen.Top / dy) : (top / dy);
+            Left = left < screen.Left ? (screen.Left / dx) : (left / dx);
 
             var image = result.Image;
 

--- a/app.manifest
+++ b/app.manifest
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- The combination of below two tags have the following effect : 
+      1) Per-Monitor for >= RS1 (Windows 10 Anniversary Update)
+      2) System < RS1 -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings"> PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
## Description
Screen snip- Not working correctly with (2) 4K screens. [ELECTRON-1009](https://perzoinc.atlassian.net/browse/ELECTRON-1009)

## Solution Approach
Basically I added the the Application Manifest File and inserted the per monitor DPI scaling support

## Fix
- before:
![before-error-screen-snippet](https://user-images.githubusercontent.com/9887288/51854916-17abda00-2313-11e9-929c-b9d4ae063339.png)

- after: 
![after-error-screen-snippet](https://user-images.githubusercontent.com/9887288/51854937-21cdd880-2313-11e9-881f-feb8bb1dc5a5.png)


## Documentation
-> https://docs.microsoft.com/en-us/windows/desktop/hidpi/high-dpi-desktop-application-development-on-windows
-> https://github.com/Microsoft/WPF-Samples/blob/master/PerMonitorDPI/Developer%20Guide%20-%20Per%20Monitor%20DPI%20-%20WPF%20Preview.docx
-> https://stackoverflow.com/questions/5977445/how-to-get-windows-display-settings
-> https://msdn.microsoft.com/en-us/library/windows/desktop/mt846517(v=vs.85).aspx
-> https://blogs.msdn.microsoft.com/jaimer/2007/03/08/getting-system-dpi-in-wpf-app/
-> https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-8.1-and-8/ff716252(v=win.10)

## Related PRs
N/A
