### PR TITLE
ELECTRON-802: ScreenSnippet improving capture quality

### DIFF
--- a/SnippingWindow.xaml.cs
+++ b/SnippingWindow.xaml.cs
@@ -163,10 +163,10 @@ namespace Paragon.Plugins.ScreenCapture
 
                 using (var fileStream = new FileStream(outputFilename, FileMode.Create))
                 {
-                    var jpegEncoder = new JpegBitmapEncoder();
-                    jpegEncoder.QualityLevel = 70;
-                    jpegEncoder.Frames.Add(BitmapFrame.Create(renderTargetBitmap));
-                    jpegEncoder.Save(fileStream);
+                    PngBitmapEncoder encoder = new PngBitmapEncoder();
+                    encoder.Interlace = PngInterlaceOption.On;
+                    encoder.Frames.Add(BitmapFrame.Create(renderTargetBitmap));
+                    encoder.Save(fileStream);
                 }
             }
             finally


### PR DESCRIPTION
## Description
Snipping tool capture quality degraded. [ELECTRON-802](https://perzoinc.atlassian.net/browse/ELECTRON-802)

## Solution Approach
It was changed the jpg to png format.

## Documentation
N/A

## Related PRs
N/A

## Fix
- Before
![before](https://user-images.githubusercontent.com/9887288/52354882-685cba80-2a18-11e9-8fd6-63bd057de1e1.jpg)

- After
![after](https://user-images.githubusercontent.com/9887288/52354902-6eeb3200-2a18-11e9-8fa0-c109130a7c88.jpg)


